### PR TITLE
Fix issue https://github.com/metaskills/mini_backtrace/issues/1

### DIFF
--- a/lib/mini_backtrace.rb
+++ b/lib/mini_backtrace.rb
@@ -1,3 +1,4 @@
+require 'rails'
 require 'rails/backtrace_cleaner'
-require 'minitest/unit'
+require 'minitest/autorun'
 require 'mini_backtrace/unit'

--- a/lib/mini_backtrace/unit.rb
+++ b/lib/mini_backtrace/unit.rb
@@ -1,7 +1,7 @@
 module MiniTest
   
   def self.filter_backtrace_with_rails(bt)
-    filter_backtrace_without_rails(Rails.backtrace_cleaner.clean(bt))
+    filter_backtrace_without_rails(::Rails.backtrace_cleaner.clean(bt))
   end
   
   class << self


### PR DESCRIPTION
Resolve module name properly.

I tested against Ruby 2.2.2 and the following gems:

```
PATH
  remote: .
  specs:
    mini_backtrace (0.1.3)
      minitest (> 1.2.0)
      rails (>= 2.3.3)

GEM
  remote: http://rubygems.org/
  specs:
    actionmailer (4.2.1)
      actionpack (= 4.2.1)
      actionview (= 4.2.1)
      activejob (= 4.2.1)
      mail (~> 2.5, >= 2.5.4)
      rails-dom-testing (~> 1.0, >= 1.0.5)
    actionpack (4.2.1)
      actionview (= 4.2.1)
      activesupport (= 4.2.1)
      rack (~> 1.6)
      rack-test (~> 0.6.2)
      rails-dom-testing (~> 1.0, >= 1.0.5)
      rails-html-sanitizer (~> 1.0, >= 1.0.1)
    actionview (4.2.1)
      activesupport (= 4.2.1)
      builder (~> 3.1)
      erubis (~> 2.7.0)
      rails-dom-testing (~> 1.0, >= 1.0.5)
      rails-html-sanitizer (~> 1.0, >= 1.0.1)
    activejob (4.2.1)
      activesupport (= 4.2.1)
      globalid (>= 0.3.0)
    activemodel (4.2.1)
      activesupport (= 4.2.1)
      builder (~> 3.1)
    activerecord (4.2.1)
      activemodel (= 4.2.1)
      activesupport (= 4.2.1)
      arel (~> 6.0)
    activesupport (4.2.1)
      i18n (~> 0.7)
      json (~> 1.7, >= 1.7.7)
      minitest (~> 5.1)
      thread_safe (~> 0.3, >= 0.3.4)
      tzinfo (~> 1.1)
    arel (6.0.0)
    builder (3.2.2)
    erubis (2.7.0)
    globalid (0.3.5)
      activesupport (>= 4.1.0)
    i18n (0.7.0)
    json (1.8.2)
    loofah (2.0.1)
      nokogiri (>= 1.5.9)
    mail (2.6.3)
      mime-types (>= 1.16, < 3)
    mime-types (2.5)
    mini_portile (0.6.2)
    minitest (5.6.1)
    nokogiri (1.6.6.2)
      mini_portile (~> 0.6.0)
    rack (1.6.0)
    rack-test (0.6.3)
      rack (>= 1.0)
    rails (4.2.1)
      actionmailer (= 4.2.1)
      actionpack (= 4.2.1)
      actionview (= 4.2.1)
      activejob (= 4.2.1)
      activemodel (= 4.2.1)
      activerecord (= 4.2.1)
      activesupport (= 4.2.1)
      bundler (>= 1.3.0, < 2.0)
      railties (= 4.2.1)
      sprockets-rails
    rails-deprecated_sanitizer (1.0.3)
      activesupport (>= 4.2.0.alpha)
    rails-dom-testing (1.0.6)
      activesupport (>= 4.2.0.beta, < 5.0)
      nokogiri (~> 1.6.0)
      rails-deprecated_sanitizer (>= 1.0.1)
    rails-html-sanitizer (1.0.2)
      loofah (~> 2.0)
    railties (4.2.1)
      actionpack (= 4.2.1)
      activesupport (= 4.2.1)
      rake (>= 0.8.7)
      thor (>= 0.18.1, < 2.0)
    rake (10.4.2)
    sprockets (3.0.3)
      rack (~> 1.0)
    sprockets-rails (2.2.4)
      actionpack (>= 3.0)
      activesupport (>= 3.0)
      sprockets (>= 2.8, < 4.0)
    thor (0.19.1)
    thread_safe (0.3.5)
    tzinfo (1.2.2)
      thread_safe (~> 0.1)

PLATFORMS
  ruby

DEPENDENCIES
  mini_backtrace!
```
